### PR TITLE
Renamed "ranges" to "intervals" to support C++20

### DIFF
--- a/Sorting and Searching/Nested Ranges Check.cpp
+++ b/Sorting and Searching/Nested Ranges Check.cpp
@@ -6,7 +6,7 @@ const int maxN = 2e5+1;
 const int SIZE = 2*maxN;
 
 int N, ans[2][maxN], ds[SIZE];
-triple ranges[maxN];
+triple intervals[maxN];
 set<int> unique_vals;
 map<int,int> mp;
 
@@ -25,11 +25,11 @@ int main(){
     scanf("%d", &N);
     for(int i = 0, x, y; i < N; i++){
         scanf("%d %d", &x, &y);
-        ranges[i] = {x, y, i};
+        intervals[i] = {x, y, i};
         unique_vals.insert(x);
         unique_vals.insert(y);
     }
-    sort(ranges, ranges+N, [](triple A, triple B){
+    sort(intervals, intervals+N, [](triple A, triple B){
         return (A[0] == B[0] ? A[1] > B[1] : A[0] < B[0]);
     });
 
@@ -38,8 +38,8 @@ int main(){
         mp[x] = val_id++;
 
     for(int i = N-1; i >= 0; i--){
-        int y = mp[ranges[i][1]];
-        int id = ranges[i][2];
+        int y = mp[intervals[i][1]];
+        int id = intervals[i][2];
 
         ans[0][id] = query(y);
         update(y, 1);
@@ -47,8 +47,8 @@ int main(){
 
     fill(ds, ds+SIZE, 0);
     for(int i = 0; i < N; i++){
-        int y = mp[ranges[i][1]];
-        int id = ranges[i][2];
+        int y = mp[intervals[i][1]];
+        int id = intervals[i][2];
 
         ans[1][id] = i-query(y-1);
         update(y, 1);

--- a/Sorting and Searching/Nested Ranges Count.cpp
+++ b/Sorting and Searching/Nested Ranges Count.cpp
@@ -6,7 +6,7 @@ const int maxN = 2e5+1;
 const int SIZE = 2*maxN;
 
 int N, ans[2][maxN], ds[SIZE];
-triple ranges[maxN];
+triple intervals[maxN];
 set<int> unique_vals;
 map<int,int> mp;
 
@@ -25,11 +25,11 @@ int main(){
     scanf("%d", &N);
     for(int i = 0, x, y; i < N; i++){
         scanf("%d %d", &x, &y);
-        ranges[i] = {x, y, i};
+        intervals[i] = {x, y, i};
         unique_vals.insert(x);
         unique_vals.insert(y);
     }
-    sort(ranges, ranges+N, [](triple A, triple B){
+    sort(intervals, intervals+N, [](triple A, triple B){
         return (A[0] == B[0] ? A[1] > B[1] : A[0] < B[0]);
     });
 
@@ -38,8 +38,8 @@ int main(){
         mp[x] = val_id++;
 
     for(int i = N-1; i >= 0; i--){
-        int y = mp[ranges[i][1]];
-        int id = ranges[i][2];
+        int y = mp[intervals[i][1]];
+        int id = intervals[i][2];
 
         ans[0][id] = query(y);
         update(y, 1);
@@ -47,8 +47,8 @@ int main(){
 
     fill(ds, ds+SIZE, 0);
     for(int i = 0; i < N; i++){
-        int y = mp[ranges[i][1]];
-        int id = ranges[i][2];
+        int y = mp[intervals[i][1]];
+        int id = intervals[i][2];
 
         ans[1][id] = i-query(y-1);
         update(y, 1);


### PR DESCRIPTION
 In C++20 the [ranges library](https://en.cppreference.com/w/cpp/ranges) was added. Because the code uses the std namespace when compiling, an ambiguity causes a compilation error. This change resolves the ambiguity.